### PR TITLE
docs(modules): add detailed usage guide for all Terraform modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# gerador-assinatura-email-infra

--- a/docs/modules-guide.md
+++ b/docs/modules-guide.md
@@ -1,0 +1,157 @@
+# Guia dos Módulos Terraform
+
+Este documento descreve os módulos disponíveis no projeto e como utilizá-los em outros projetos Terraform.
+
+---
+
+## 1. Módulo VPC
+
+**Caminho:** `terraform/modules/vpc`
+
+### Descrição
+Provisiona uma VPC pública, incluindo subnet pública, internet gateway e tabela de rotas.
+
+### Parâmetros
+| Nome                | Tipo        | Obrigatório | Descrição                                      |
+|---------------------|-------------|-------------|------------------------------------------------|
+| `cidr_block`        | string      | Sim         | CIDR block da VPC (ex: "10.0.0.0/16")        |
+| `public_subnet_cidr`| string      | Sim         | CIDR block da subnet pública                   |
+| `availability_zone` | string      | Sim         | Zona de disponibilidade (ex: "us-east-1a")   |
+| `tags`              | map(string) | Não         | Tags para os recursos (default: `{}`)          |
+
+### Outputs
+| Nome                | Descrição                                  |
+|---------------------|--------------------------------------------|
+| `vpc_id`            | ID da VPC criada                           |
+| `public_subnet_id`  | ID da subnet pública criada                |
+
+### Exemplo de uso
+```hcl
+module "vpc" {
+  source              = "../modules/vpc"
+  cidr_block          = "10.0.0.0/16"
+  public_subnet_cidr  = "10.0.1.0/24"
+  availability_zone   = "us-east-1a"
+  tags = {
+    Environment = "dev"
+    Project     = "meu-projeto"
+  }
+}
+```
+
+---
+
+## 2. Módulo EC2
+
+**Caminho:** `terraform/modules/ec2`
+
+### Descrição
+Provisiona uma instância EC2, pronta para rodar um container Docker.
+
+### Parâmetros
+| Nome                  | Tipo         | Obrigatório | Descrição                                         |
+|-----------------------|--------------|-------------|---------------------------------------------------|
+| `ami`                 | string       | Sim         | ID da AMI a ser utilizada                         |
+| `instance_type`       | string       | Sim         | Tipo da instância EC2 (ex: "t2.micro")          |
+| `subnet_id`           | string       | Sim         | ID da subnet onde a EC2 será criada               |
+| `security_group_ids`  | list(string) | Sim         | Lista de IDs de security groups                   |
+| `iam_instance_profile`| string       | Não         | Perfil IAM para a EC2 (default: `null`)           |
+| `user_data`           | string       | Não         | Script de inicialização (ex: para instalar Docker) |
+| `tags`                | map(string)  | Não         | Tags para os recursos (default: `{}`)             |
+
+### Outputs
+| Nome         | Descrição                |
+|--------------|-------------------------|
+| `instance_id`| ID da instância EC2     |
+| `public_ip`  | IP público da EC2       |
+
+### Exemplo de uso
+```hcl
+module "ec2" {
+  source              = "../modules/ec2"
+  ami                 = "ami-xxxxxxxx"
+  instance_type       = "t2.micro"
+  subnet_id           = module.vpc.public_subnet_id
+  security_group_ids  = [module.security_group.security_group_id]
+  iam_instance_profile = null
+  user_data           = ""
+  tags = {
+    Environment = "dev"
+    Project     = "meu-projeto"
+  }
+}
+```
+
+---
+
+## 3. Módulo Security Group
+
+**Caminho:** `terraform/modules/security_group`
+
+### Descrição
+Cria um security group para EC2 pública, liberando portas 80, 443 e 22 para o mundo.
+
+### Parâmetros
+| Nome     | Tipo        | Obrigatório | Descrição                        |
+|----------|-------------|-------------|----------------------------------|
+| `name`   | string      | Sim         | Nome do security group           |
+| `vpc_id` | string      | Sim         | ID da VPC                        |
+| `tags`   | map(string) | Não         | Tags para os recursos (default: `{}`) |
+
+### Outputs
+| Nome               | Descrição                |
+|--------------------|-------------------------|
+| `security_group_id`| ID do security group     |
+
+### Exemplo de uso
+```hcl
+module "security_group" {
+  source = "../modules/security_group"
+  name   = "dev-ec2-sg"
+  vpc_id = module.vpc.vpc_id
+  tags = {
+    Environment = "dev"
+    Project     = "meu-projeto"
+  }
+}
+```
+
+---
+
+## 4. Módulo ECR
+
+**Caminho:** `terraform/modules/ecr`
+
+### Descrição
+Cria um repositório ECR para armazenar imagens Docker.
+
+### Parâmetros
+| Nome   | Tipo        | Obrigatório | Descrição                        |
+|--------|-------------|-------------|----------------------------------|
+| `name` | string      | Sim         | Nome do repositório ECR          |
+| `tags` | map(string) | Não         | Tags para o repositório (default: `{}`) |
+
+### Outputs
+| Nome            | Descrição                        |
+|-----------------|---------------------------------|
+| `repository_url`| URL do repositório ECR criado    |
+
+### Exemplo de uso
+```hcl
+module "ecr" {
+  source = "../modules/ecr"
+  name   = "meu-projeto-ecr"
+  tags = {
+    Environment = "dev"
+    Project     = "meu-projeto"
+  }
+}
+```
+
+---
+
+## Como reutilizar os módulos
+
+- Use o parâmetro `source` para apontar para o caminho relativo do módulo ou para o repositório Git.
+- Consulte sempre o arquivo `variables.tf` de cada módulo para saber os parâmetros obrigatórios e opcionais.
+- Utilize os outputs dos módulos para conectar recursos entre si (ex: passar o `public_subnet_id` do módulo VPC para o EC2). 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,81 @@
+# Guia do Usuário - Provisionamento de Infraestrutura
+
+Este guia fornece instruções passo a passo para desenvolvedores provisionarem e gerenciarem a infraestrutura do projeto **gerador-assinatura-email** utilizando Terraform.
+
+---
+
+## Pré-requisitos
+
+- **Conta AWS:** Você deve ter acesso a uma conta AWS com permissões para criar e gerenciar recursos (VPC, EC2, ECR, S3, DynamoDB, etc).
+- **AWS CLI:** [Instale e configure o AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+- **Credenciais AWS:**  
+  Configure suas credenciais AWS localmente usando:
+  ```sh
+  aws configure
+  ```
+  Ou defina as seguintes variáveis de ambiente:
+  ```sh
+  export AWS_ACCESS_KEY_ID=sua-access-key
+  export AWS_SECRET_ACCESS_KEY=seu-secret-key
+  export AWS_DEFAULT_REGION=us-east-1
+  ```
+- **Terraform:** [Instale o Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli) (versão >= 1.3.0).
+
+---
+
+## Configuração Inicial
+
+1. **Clone o repositório:**
+   ```sh
+   git clone https://github.com/your-org/gerador-assinatura-email-infra.git
+   cd gerador-assinatura-email-infra/terraform/environments/staging
+   ```
+
+2. **Crie o bucket S3 e a tabela DynamoDB para o state remoto:**
+   - Bucket S3: `meu-terraform-state-staging`
+   - Tabela DynamoDB: `meu-terraform-lock-table` com chave primária `LockID` (String)
+   - Exemplo usando AWS CLI:
+     ```sh
+     aws s3 mb s3://meu-terraform-state-staging
+     aws dynamodb create-table \
+       --table-name meu-terraform-lock-table \
+       --attribute-definitions AttributeName=LockID,AttributeType=S \
+       --key-schema AttributeName=LockID,KeyType=HASH \
+       --billing-mode PAY_PER_REQUEST
+     ```
+
+3. **Inicialize o Terraform:**
+   ```sh
+   terraform init
+   ```
+
+4. **Revise e aplique o plano:**
+   ```sh
+   terraform plan -out=plan
+   terraform apply plan
+   ```
+
+---
+
+## Observações
+
+- **Nunca faça commit das suas credenciais AWS** no repositório.
+- Cada ambiente (`staging`, `production`) possui sua própria configuração e state.
+- A AMI utilizada para a EC2 é definida no arquivo `.tfvars` de cada ambiente.
+- A infraestrutura inclui VPC, subnet pública, instância EC2 (para Docker), Security Group e repositório ECR.
+
+---
+
+## Solução de Problemas
+
+- Se encontrar erros de state lock, verifique se a tabela DynamoDB está configurada corretamente.
+- Para erros de região ou provider, confira se `aws_region` está definida nas variáveis ou no arquivo `.tfvars`.
+
+---
+
+## Links Úteis
+
+- [Documentação do Provider AWS para Terraform](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
+- [Documentação AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
+
+--- 


### PR DESCRIPTION
Este commit adiciona um arquivo de documentação abrangente (`docs/modules-guide.md`) que descreve todos os módulos Terraform disponíveis no projeto. A documentação inclui:

- **Visão geral dos módulos:** Propósito e utilização de cada módulo (VPC, EC2, Security Group, ECR).
- **Tabela de parâmetros:** Explicação detalhada de todas as variáveis de entrada de cada módulo, indicando quais são obrigatórias e suas descrições.
- **Tabela de outputs:** Lista e descrição de todos os outputs fornecidos por cada módulo.
- **Exemplos de uso:** Trechos de código práticos mostrando como utilizar cada módulo em uma configuração Terraform.
- **Boas práticas:** Orientações sobre como reutilizar módulos, conectar outputs e manter a consistência entre projetos.

Esta documentação tem como objetivo facilitar a reutilização dos módulos, melhorar o onboarding de novos desenvolvedores e garantir boas práticas em infraestrutura como código.