### PR TITLE
feat(ec2): add user_data script to install and configure Docker on in…

### DIFF
--- a/terraform/environments/developer/.terraform.lock.hcl
+++ b/terraform/environments/developer/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.0.0"
+  hashes = [
+    "h1:DhxTTyLjzmC0wRCodYOWkIGwHAYb2Fcg3zFc/3sIpvk=",
+    "zh:16b1bb786719b7ebcddba3ab751b976ebf4006f7144afeebcb83f0c5f41f8eb9",
+    "zh:1fbc08b817b9eaf45a2b72ccba59f4ea19e7fcf017be29f5a9552b623eccc5bc",
+    "zh:304f58f3333dbe846cfbdfc2227e6ed77041ceea33b6183972f3f8ab51bd065f",
+    "zh:4cd447b5c24f14553bd6e1a0e4fea3c7d7b218cbb2316a3d93f1c5cb562c181b",
+    "zh:589472b56be8277558616075fc5480fcd812ba6dc70e8979375fc6d8750f83ef",
+    "zh:5d78484ba43c26f1ef6067c4150550b06fd39c5d4bfb790f92c4a6f7d9d0201b",
+    "zh:5f470ce664bffb22ace736643d2abe7ad45858022b652143bcd02d71d38d4e42",
+    "zh:7a9cbb947aaab8c885096bce5da22838ca482196cf7d04ffb8bdf7fd28003e47",
+    "zh:854df3e4c50675e727705a0eaa4f8d42ccd7df6a5efa2456f0205a9901ace019",
+    "zh:87162c0f47b1260f5969679dccb246cb528f27f01229d02fd30a8e2f9869ba2c",
+    "zh:9a145404d506b52078cd7060e6cbb83f8fc7953f3f63a5e7137d41f69d6317a3",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a4eab2649f5afe06cc406ce2aaf9fd44dcf311123f48d344c255e93454c08921",
+    "zh:bea09141c6186a3e133413ae3a2e3d1aaf4f43466a6a468827287527edf21710",
+    "zh:d7ea2a35ff55ddfe639ab3b04331556b772a8698eca01f5d74151615d9f336db",
+  ]
+}

--- a/terraform/environments/developer/backend.tf
+++ b/terraform/environments/developer/backend.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    bucket         = "meu-terraform-state-developer"
-    key            = "developer/terraform.tfstate"
+    bucket         = "gerador-template-email"
+    key            = "staging/terraform.tfstate"
     region         = "us-east-1"
-    dynamodb_table = "meu-terraform-lock-table"
+    dynamodb_table = "gerador-template-email-lock-table"
     encrypt        = true
   }
 } 

--- a/terraform/environments/developer/main.tf
+++ b/terraform/environments/developer/main.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+}
+
 module "vpc" {
   source              = "../../modules/vpc"
   cidr_block          = "10.30.0.0/16"
@@ -26,7 +30,7 @@ module "ec2" {
   subnet_id           = module.vpc.public_subnet_id
   security_group_ids  = [module.security_group.security_group_id]
   iam_instance_profile = var.iam_instance_profile
-  user_data           = var.user_data
+  user_data           = file("${path.module}/user_data.sh")
   tags = {
     Environment = "developer"
     Project     = "gerador-assinatura-email"

--- a/terraform/environments/developer/user_data.sh
+++ b/terraform/environments/developer/user_data.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Atualiza os pacotes
+yum update -y
+
+# Habilita e instala o Docker
+amazon-linux-extras enable docker
+yum install -y docker
+
+# Inicia o serviço Docker
+service docker start
+
+# Adiciona o ec2-user ao grupo docker
+usermod -aG docker ec2-user
+
+# Habilita o Docker na inicialização
+systemctl enable docker 

--- a/terraform/environments/developer/variables.tf
+++ b/terraform/environments/developer/variables.tf
@@ -1,3 +1,9 @@
+variable "aws_region" {
+  description = "Região AWS"
+  type        = string
+  default     = "us-east-1"
+}
+
 variable "ami" {
   description = "AMI para EC2"
   type        = string


### PR DESCRIPTION
### Descrição

Este PR adiciona um script de inicialização (`user_data.sh`) ao ambiente **developer** para automatizar a instalação e configuração do Docker na instância EC2 durante o provisionamento.

#### Principais pontos:

- **Novo arquivo:**  
  - `terraform/environments/developer/user_data.sh`: Script shell que realiza atualização dos pacotes, habilita e instala o Docker, adiciona o usuário `ec2-user` ao grupo `docker` e garante que o serviço Docker será iniciado automaticamente.

- **Integração com o Terraform:**  
  - O arquivo `main.tf` do ambiente developer foi ajustado para utilizar o conteúdo do `user_data.sh` como parâmetro `user_data` na criação da instância EC2.
  - Isso garante que toda nova instância EC2 provisionada já estará pronta para rodar containers Docker sem necessidade de configuração manual.

#### Benefícios

- Automatiza o setup do ambiente de desenvolvimento na EC2.
- Reduz erros manuais e acelera o onboarding de novos desenvolvedores.
- Garante que todas as instâncias estejam padronizadas e prontas para uso com Docker.
