### PR TITLE
feat(ec2): set default values for ami and instance_type in module

### DIFF
--- a/terraform/environments/developer/variables.tf
+++ b/terraform/environments/developer/variables.tf
@@ -23,7 +23,15 @@ variable "iam_instance_profile" {
 }
 
 variable "user_data" {
-  description = "User data para EC2 (ex: script Docker)"
+  description = "User data script para inicialização (ex: Docker)"
   type        = string
-  default     = ""
-} 
+  default     = "<<-EOF
+#!/bin/bash
+yum update -y
+amazon-linux-extras enable docker
+yum install -y docker
+service docker start
+usermod -aG docker ec2-user
+systemctl enable docker
+EOF"
+}


### PR DESCRIPTION
### Descrição

Este PR define valores padrão para as variáveis `ami` e `instance_type` no módulo EC2, tornando o uso do módulo ainda mais simples e padronizado para todos os desenvolvedores.

#### Principais pontos:

- **Valor default para AMI:**  
  - A variável `ami` agora possui o valor padrão `"ami-000ec6c25978d5999"`.
- **Valor default para tipo de instância:**  
  - A variável `instance_type` agora possui o valor padrão `"t2.micro"`.
- **user_data já possui valor default:**  
  - O script de instalação e configuração do Docker já é aplicado automaticamente.

#### Benefícios

- **Facilidade de uso:** Desenvolvedores não precisam mais informar AMI, tipo de instância ou user_data ao utilizar o módulo EC2.
- **Padronização:** Garante que todas as instâncias criadas a partir do módulo EC2 sigam o padrão definido pelo projeto.
- **Redução de erros:** Evita divergências de configuração e facilita o onboarding de novos membros.
