### PR TITLE
feat(vpc): set default values for cidr_block, public_subnet_cidr and …

### DIFF
--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,16 +1,19 @@
 variable "cidr_block" {
   description = "CIDR block da VPC"
   type        = string
+  default     = "10.0.0.0/16"
 }
 
 variable "public_subnet_cidr" {
   description = "CIDR block da subnet pública"
   type        = string
+  default     = "10.0.1.0/24"
 }
 
 variable "availability_zone" {
   description = "Zona de disponibilidade para a subnet pública"
   type        = string
+  default     = "us-east-1a"
 }
 
 variable "tags" {


### PR DESCRIPTION
### Descrição

Este Pull Request define valores padrão para variáveis do módulo VPC, facilitando o uso do módulo e promovendo padronização na criação de redes.

#### Modificações realizadas:

- Adicionados valores default para variáveis do módulo VPC, como:
  - `cidr_block`
  - `public_subnet_cidr`
  - `availability_zone`
  - (e outras, se aplicável)
- Agora, ao utilizar o módulo VPC, não é mais obrigatório informar todos os parâmetros, tornando o uso mais simples e seguro para desenvolvedores.
- Mantém a flexibilidade para sobrescrever os valores default caso seja necessário em ambientes específicos.

#### Benefícios

- **Facilidade de uso:** Reduz a quantidade de parâmetros obrigatórios ao consumir o módulo.
- **Padronização:** Garante que, na ausência de parâmetros customizados, a infraestrutura siga um padrão definido pelo projeto.
- **Redução de erros:** Minimiza a chance de erros de configuração por omissão de variáveis importantes.
